### PR TITLE
Update PSUM_ADD.v

### DIFF
--- a/src/PSUM_ADD.v
+++ b/src/PSUM_ADD.v
@@ -7,12 +7,12 @@ module PSUM_ADD #(
 ) (
     input clk,
     input rst_n,
-    input signed [data_width-1:0] pe0_data,
-    input signed [data_width-1:0] pe1_data,
-    input signed [data_width-1:0] pe2_data,
-    input signed [data_width-1:0] pe3_data,
-    input signed [data_width-1:0] fifo_data,
-    output signed [data_width-1:0] out
+    input wire signed [data_width-1:0] pe0_data,
+    input wire signed [data_width-1:0] pe1_data,
+    input wire signed [data_width-1:0] pe2_data,
+    input wire signed [data_width-1:0] pe3_data,
+    input wire signed [data_width-1:0] fifo_data,
+    output wire signed [data_width-1:0] out
 );
 
     reg signed [data_width-1:0] psum0;


### PR DESCRIPTION
As you might know, since verilog 2001, wires are implicitly declared in verilog.That means you can start using a net in verilog and assume as if you declared it as a single bit wire. The important thing to notice here is that as long as you use it as a single bit wire, you are safe.
If verilog was "C" , i would have appreciated this feature or called it as an "enhancement".

But it is not. Verilog is meant to write RTLs. While writing RTL, the more you are forced to be specific ,the lesser error prone you are making the environment.